### PR TITLE
Add discussion template for maintenance announcements

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/maintenance-announcement-template.md
+++ b/.github/DISCUSSION_TEMPLATE/maintenance-announcement-template.md
@@ -1,0 +1,27 @@
+---
+name: Maintenance Announcement
+about: Create a maintenance announcement for compute cluster users
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Hi @watonomous/watcloud-compute-cluster-users,
+
+This is a maintenance announcement. Please see below for details.
+
+**Machines Affected:**
+<!-- List the machines that will be affected by this maintenance. -->
+
+**Duration:**
+<!-- Specify the duration of the maintenance. -->
+
+**Start Time:**
+<!-- Specify the start time of the maintenance. Use daylight-savings-agnostic timestamps (e.g. use `ET` instead of `EST` or `EDT` for Eastern Time) -->
+
+**Purpose:**
+<!-- Briefly describe the purpose of the maintenance. -->
+
+**Additional Information:**
+<!-- Include any additional information or instructions here. -->


### PR DESCRIPTION
Resolves #21

Adds a new maintenance announcement template for compute cluster users to the repository.

- Introduces a new file `.github/DISCUSSION_TEMPLATE/maintenance-announcement-template.md` to standardize maintenance announcements.
- Prepopulates mentions of the `@watonomous/watcloud-compute-cluster-users` group to ensure they are notified.
- Includes prompts for essential details such as "Machines Affected", "Duration", "Start Time", and "Purpose" to provide clear and comprehensive maintenance information.
- Advises on the use of daylight-savings-agnostic timestamps (e.g., `ET` for Eastern Time) to avoid confusion related to time zones.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WATonomous/infrastructure-support/issues/21?shareId=4adc8f6b-46cf-4de7-887f-eea34aed92f3).